### PR TITLE
Fix V575 warning from PVS-Studio Static Analyzer

### DIFF
--- a/h264_stream.c
+++ b/h264_stream.c
@@ -31,6 +31,10 @@ h264_stream_t *h264_stream_from_file(char *path)
     rewind(fp);
     
     buffer = (uint8_t *)malloc(file_size);
+    if (buffer == NULL)
+    {
+        return (NULL);
+    }
     assert(buffer);
     
     result = fread(buffer, 1, file_size, fp);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
The potential null pointer is passed into 'fread' function.