### PR TITLE
Fix V701 warning from PVS-Studio Static Analyzer

### DIFF
--- a/CuTest.c
+++ b/CuTest.c
@@ -49,8 +49,12 @@ CuString* CuStringNew(void)
 
 void CuStringResize(CuString* str, int newSize)
 {
-	str->buffer = (char*) realloc(str->buffer, sizeof(char) * newSize);
-	str->size = newSize;
+        char *t = (char*) realloc(str->buffer, sizeof(char) * newSize);
+        if (t)
+        {
+            str->buffer = t;
+            str->size = newSize;
+        }
 }
 
 void CuStringAppend(CuString* str, const char* text)


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
realloc() possible leak: when realloc() fails in allocating memory,
original pointer 'str->buffer' is lost.
Consider assigning realloc() to a temporary pointer.