### PR TITLE
Fix V522 warning from PVS-Studio Static Analyzer

### DIFF
--- a/h264_stream.c
+++ b/h264_stream.c
@@ -7,10 +7,13 @@
 h264_stream_t *h264_stream_new(uint8_t *data, int size)
 {
     h264_stream_t *s = malloc(sizeof(h264_stream_t));
-    s->data = data;
-    s->size = size;
-    s->bit_pos = 7;
-    s->byte_pos = 0;
+    if (s)
+    {
+        s->data = data;
+        s->size = size;
+        s->bit_pos = 7;
+        s->byte_pos = 0;
+    }
     return s;
 }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
There might be dereferencing of a potential null pointer 's'.